### PR TITLE
Tested with Unity 4.5 and bug seems to be fixed.

### DIFF
--- a/Syphon Implementations/Unity3D/Unity3D-3_5/SyphonUnityExample/Assets/Plugins/SyphonTexture-AdvancedUsers/SyphonServerTextureCustomResolution.cs
+++ b/Syphon Implementations/Unity3D/Unity3D-3_5/SyphonUnityExample/Assets/Plugins/SyphonTexture-AdvancedUsers/SyphonServerTextureCustomResolution.cs
@@ -117,8 +117,6 @@ public class SyphonServerTextureCustomResolution : SyphonServerTexture {
 		}
 
 		if(Event.current.type.Equals(EventType.Repaint)){	
-			//clear with a black background (GL.Clear adds weird artifacts if called here...dunno why, unity bug?)
-			GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), Syphon.NullTexture,  ScaleMode.ScaleAndCrop, false, 0); 
 			//draw the scene rendertexture, but fit it to the window.
 			if(drawScene)
 			GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), customRenderTexture,  ScaleMode.ScaleToFit, false, 0); 


### PR DESCRIPTION
We are using a Unity camera without Syphon, and the GUI.DrawTexture method renders on top of this camera in the Game window even with different camera depth settings.
